### PR TITLE
Adds 'open in the other pane'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Opens the associated file mapping in the current pane
 
 Switches to the associated mapping in a pane to the left or right
 
+#### Switch Header (Other) Pane
+
+Switches to the associated mapping in a different pane than the current one.
+
 #### Toggle Header/Source Tracking Mode 
 
 Toggles the tracking mode on/off, which will automatically open the equivalent header/source file (or other mapping) in an adjacent pane when the current pane switches files.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "onCommand:extension.switch",
     "onCommand:extension.switchRightPane",
     "onCommand:extension.switchLeftPane",
+    "onCommand:extension.switchOtherPane",
     "onCommand:extension.toggleTracker"
   ],
   "main": "./out/src/extension",
@@ -39,6 +40,10 @@
       {
         "command": "extension.switchLeftPane",
         "title": "Switch Header/Source To Left Pane"
+      },
+      {
+        "command": "extension.switchOtherPane",
+        "title": "Switch Header/Source To The Other Pane"
       },
       {
         "command": "extension.toggleTracker",

--- a/src/codeOperations.ts
+++ b/src/codeOperations.ts
@@ -113,6 +113,11 @@ export async function openFileInPane(pane:FilePane)
         case FilePane.Right:
             viewColumn = currentColumn + 1;
             break;
+        case FilePane.Other:
+            viewColumn = (currentColumn == vscode.ViewColumn.One ?
+                            vscode.ViewColumn.Two :
+                            currentColumn - 1);
+            break;
     }
 
     openFile(fileName, viewColumn);
@@ -122,7 +127,8 @@ export enum FilePane
 {
     Current,
     Left,
-    Right
+    Right,
+    Other,
 }
 
 export var changeTracker = new DocumentTracker();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,12 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(switchLeftPaneDisposable);
 
+    let switchOtherPaneDisposable = vscode.commands.registerCommand('extension.switchOtherPane', async () => {
+        openFileInPane(FilePane.Other);
+    });
+
+    context.subscriptions.push(switchOtherPaneDisposable);
+
     let toggleChangeTrackingDisposable = vscode.commands.registerCommand('extension.toggleTracker', async () => {
         toggleTracking();
     });


### PR DESCRIPTION
Adds a command to support opening the matching source/header file in 'the
other' pane. Useful to have the source/header next to each other in a two-pane
setup regardless of the current column we're in.