### PR TITLE
Support Win7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.17",
-        "@types/vscode": "^1.75.0",
+        "@types/vscode": "^1.70.0",
         "@vscode/test-cli": "^0.0.11",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.5.0",
@@ -20,7 +20,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.70.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.70.0"
   },
   "categories": [
     "Other"
@@ -93,7 +93,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.17",
-    "@types/vscode": "^1.75.0",
+    "@types/vscode": "^1.70.0",
     "@vscode/test-cli": "^0.0.11",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.5.0",


### PR DESCRIPTION
Apparently the last supported versions for vs code on Windows 7 are 1.70.x 

This doesn't have any dependencies need on versions past that so just downgrade.